### PR TITLE
when executing the SDK, it reports a missing merchantCustomerId error…

### DIFF
--- a/stubs/hostedcheckouts/create.json
+++ b/stubs/hostedcheckouts/create.json
@@ -7,7 +7,8 @@
     "customer" : {
       "billingAddress" : {
         "countryCode" : "US"
-      }
+      },
+      "merchantCustomerId": "12314"
     }
   },
   "hostedCheckoutSpecificInput" : {


### PR DESCRIPTION
…. Added missing field so that the GET request can complete correctly