### PR TITLE
Fix create payment gender field -

### DIFF
--- a/stubs/hostedcheckouts/create.json
+++ b/stubs/hostedcheckouts/create.json
@@ -7,7 +7,8 @@
     "customer" : {
       "billingAddress" : {
         "countryCode" : "US"
-      }
+      },
+      "merchantCustomerId": "12314"
     }
   },
   "hostedCheckoutSpecificInput" : {

--- a/stubs/payments/create.json
+++ b/stubs/payments/create.json
@@ -13,7 +13,7 @@
           "surnamePrefix" : "E.",
           "surname" : "Coyote"
         },
-        "gender" : "M",
+        "gender" : "male",
         "dateOfBirth" : "19490917"
       },
       "companyInformation" : {


### PR DESCRIPTION
Expects "male" not "M".

Has dependancy on https://github.com/Ingenico-ePayments/connect-sdk-nodejs-example/pull/2 because I didn't branch again from master
